### PR TITLE
Develop - 동물 프로필 이미지 등록 시 분기 처리

### DIFF
--- a/src/main/java/com/example/server/domain/pet/api/PetProfileController.java
+++ b/src/main/java/com/example/server/domain/pet/api/PetProfileController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,12 +35,13 @@ public class PetProfileController {
 
 	private final PetService petService;
 
-	@PostMapping("/profile")
+	@PostMapping("/profile/{pet-id}")
 	public ResponseEntity<PetProfileResponse> createPetProfile(
+		@PathVariable("pet-id") Long petId,
 		@RequestBody PetProfileCreateRequest reqDto,
 		@AuthenticationPrincipal UserDetails userDetails
 	) {
-		Pet pet = petService.createProfile(reqDto, userDetails.getUsername());
+		Pet pet = petService.createProfile(petId, reqDto, userDetails.getUsername());
 		PetProfileResponse response = builder()
 			.petId(pet.getId())
 			.providerId(userDetails.getUsername())
@@ -51,11 +53,12 @@ public class PetProfileController {
 		return ApiResponse.created(response);
 	}
 
-	@PostMapping(value = "/profile/images", consumes = MULTIPART_FORM_DATA_VALUE)
+	// [동물 신규 생성 시 프로필 이미지 등록] 또는 [프로필 이미지 업데이트] 모두에 활용
+	@PostMapping(value = "/profile/images/{pet-id}", consumes = MULTIPART_FORM_DATA_VALUE)
 	public ResponseEntity<Image> uploadPetProfileImage(
+		@PathVariable("pet-id") Long petId,
 		@RequestParam MultipartFile multipartFile,
-		@AuthenticationPrincipal UserDetails userDetails,
-		@RequestParam Long petId
+		@AuthenticationPrincipal UserDetails userDetails
 	) throws IOException {
 		Pet pet = petService.uploadProfileImage(
 			userDetails.getUsername(),

--- a/src/main/java/com/example/server/domain/pet/api/PetProfileController.java
+++ b/src/main/java/com/example/server/domain/pet/api/PetProfileController.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -60,6 +61,14 @@ public class PetProfileController {
 			petId,
 			multipartFile);
 		return ApiResponse.success(pet.getProfile());
+	}
+
+	/**
+	 * 다음 PET ID 발급 (동물 프로필 이미지 저장 시 필요)
+	 */
+	@GetMapping("/issue-id")
+	public ResponseEntity<Long> issueId() {
+		return ApiResponse.success(petService.issueId());
 	}
 
 }

--- a/src/main/java/com/example/server/domain/pet/api/PetProfileController.java
+++ b/src/main/java/com/example/server/domain/pet/api/PetProfileController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.example.server.domain.image.model.Image;
+import com.example.server.domain.pet.api.dto.PetIdResponse;
 import com.example.server.domain.pet.api.dto.PetProfileCreateRequest;
 import com.example.server.domain.pet.api.dto.PetProfileResponse;
 import com.example.server.domain.pet.application.PetService;
@@ -67,7 +68,7 @@ public class PetProfileController {
 	 * 다음 PET ID 발급 (동물 프로필 이미지 저장 시 필요)
 	 */
 	@GetMapping("/issue-id")
-	public ResponseEntity<Long> issueId() {
+	public ResponseEntity<PetIdResponse> issueId() {
 		return ApiResponse.success(petService.issueId());
 	}
 

--- a/src/main/java/com/example/server/domain/pet/api/dto/PetIdResponse.java
+++ b/src/main/java/com/example/server/domain/pet/api/dto/PetIdResponse.java
@@ -1,0 +1,16 @@
+package com.example.server.domain.pet.api.dto;
+
+import static lombok.AccessLevel.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+public class PetIdResponse {
+	Long petId;
+}

--- a/src/main/java/com/example/server/domain/pet/application/PetService.java
+++ b/src/main/java/com/example/server/domain/pet/application/PetService.java
@@ -10,6 +10,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.example.server.domain.member.model.Member;
 import com.example.server.domain.member.persistence.MemberRepository;
+import com.example.server.domain.pet.api.dto.PetIdResponse;
 import com.example.server.domain.pet.api.dto.PetProfileCreateRequest;
 import com.example.server.domain.pet.model.Pet;
 import com.example.server.domain.pet.model.PetInfo;
@@ -92,7 +93,9 @@ public class PetService {
 		return pet;
 	}
 
-	public Long issueId() {
-		return petRepository.getLastId() + 1L;
+	public PetIdResponse issueId() {
+		return PetIdResponse.builder()
+			.petId(petRepository.getLastId() + 1L)
+			.build();
 	}
 }

--- a/src/main/java/com/example/server/domain/pet/application/PetService.java
+++ b/src/main/java/com/example/server/domain/pet/application/PetService.java
@@ -91,4 +91,8 @@ public class PetService {
 		pet.updateProfileImage(s3Uploader.uploadSingleImage(multipartFile, DIR_NAME));
 		return pet;
 	}
+
+	public Long issueId() {
+		return petRepository.getLastId() + 1L;
+	}
 }

--- a/src/main/java/com/example/server/domain/pet/model/Pet.java
+++ b/src/main/java/com/example/server/domain/pet/model/Pet.java
@@ -88,4 +88,16 @@ public class Pet extends BaseEntity {
 	public void updateProfileImage(Image image) {
 		this.profile = image;
 	}
+
+	public void updateOwner(Member owner) {
+		this.owner = owner;
+	}
+
+	public void updatePetInfo(PetInfo petInfo) {
+		this.petInfo = petInfo;
+	}
+
+	public void updatePetTempProtectedInfo(PetTempProtectedInfo petTempProtectedInfo) {
+		this.petTempProtectedInfo = petTempProtectedInfo;
+	}
 }

--- a/src/main/java/com/example/server/domain/pet/persistence/PetRepository.java
+++ b/src/main/java/com/example/server/domain/pet/persistence/PetRepository.java
@@ -21,4 +21,7 @@ public interface PetRepository extends JpaRepository<Pet, Long> {
 	Optional<Pet> findPetById(Long petId);
 
 	Optional<Pet> findPetByIdAndOwner(Long petId, Member owner);
+
+	@Query("SELECT MAX(p.id) FROM Pet p")
+	Long getLastId();
 }

--- a/src/main/java/com/example/server/global/exception/errorcode/PetErrorCode.java
+++ b/src/main/java/com/example/server/global/exception/errorcode/PetErrorCode.java
@@ -24,7 +24,8 @@ public enum PetErrorCode implements ErrorCode {
 	PET_TEMP_PROTECTED_SRT_DATE_IN_FUTURE(3011, "반려동물 임시보호 시작일은 미래일 수 없습니다.", BAD_REQUEST),
 	PET_TEMP_PROTECTED_SRT_DATE_INVALID(3012, "반려동물 임시보호 시작일이 유효하지 않습니다.", BAD_REQUEST),
 	PET_NOT_FOUND(3013, "반려 동물 정보를 찾을 수 없습니다.", NOT_FOUND),
-	PET_SEX_INVALID(3014, "반려 동물 성별이 유효하지 않습니다.", NOT_FOUND);
+	PET_SEX_INVALID(3014, "반려 동물 성별이 유효하지 않습니다.", NOT_FOUND),
+	PET_ALREADY_EXIST(3015, "이미 존재하는 동물입니다.", CONFLICT);
 
 	private final int code;
 	private final String description;


### PR DESCRIPTION
### 🧐 Motivation
- 동물 프로필 이미지 등록 시 `petId`가 필요한데, 기존에는 `petId`에 해당하는 pet이 존재하지 않으면 익셉션 발생
- 하지만 신규 동물을 등록할 때에는 `petId`가 없는게 당연한 상황이었음

<br>

### 🎯 Key Changes
- 신규 동물 등록 시와 기존 동물의 프로필 이미지 업데이트 상황을 분기처리하여 해결
- 신규 동물 등록 시
    - 해당 `petId`에 해당하는 동물을 먼저 생성 후 이미지 등록
- 기존 동물 업데이트 시
    - 이미지 갱신


