### PR TITLE
feat: 파일 업로드 사이즈 제한 설정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,11 @@
+server:
+  tomcat:
+    max-http-form-post-size: 10MB
 spring:
   servlet:
     multipart:
-      max-file-size: 30MB
-      max-request-size: 30MB
+      max-file-size: 20MB
+      max-request-size: 20MB
   profiles:
     active: dev
     include:


### PR DESCRIPTION
### 🧐 Motivation
- 클라이언트에서 이미지 업로드 요청 시 `maxPostSize` 에러가 발생합니다.

<br>

### 🎯 Key Changes
- `application.yml` 설정에서 `server.tomcat.max-http-form-post-size`를 10MB로 설정했습니다.


